### PR TITLE
MF-30: Adding css and docs for Main Content (navigation)

### DIFF
--- a/src/inputs/input.css
+++ b/src/inputs/input.css
@@ -8,7 +8,6 @@ input.omrs-input-underlined,
 input.omrs-input-filled,
 input.omrs-input-outlined {
   font-size: 1rem;
-  box-sizing: border-box;
   width: 100%;
   height: 3.5rem;
   padding-left: 0.875rem;

--- a/src/main-content/main-content.css
+++ b/src/main-content/main-content.css
@@ -1,0 +1,14 @@
+:root {
+  --omrs-sidenav-width: 16.25rem;
+  --omrs-topnav-height: 3.5rem;
+}
+
+.omrs-main-content {
+  margin-top: var(--omrs-topnav-height);
+  margin-left: 0;
+  transition: margin-left 0.5s ease;
+}
+
+body.omrs-sidenav-expanded .omrs-main-content {
+  margin-left: var(--omrs-sidenav-width);
+}

--- a/src/main-content/main-content.stories.html
+++ b/src/main-content/main-content.stories.html
@@ -1,0 +1,18 @@
+<article class="main-content-stories">
+  <h2>Main Content</h2>
+  <p>
+    The main content of a page must respect the positioning top and side
+    navbars, including whether the side nav is expanded or not. To accomplish
+    this, the styleguide provides the `omrs-main-content` css class.
+  </p>
+  <p>
+    Note that it is best to use the <code>&lt;main&gt;</code> element instead of
+    a div for your main content, since that will help screen readers assist the
+    user in finding the main content of the current page.
+  </p>
+  <div class="stories-example lang-html">
+    <main class="omrs-main-content">
+      Put your main content here
+    </main>
+  </div>
+</article>

--- a/src/main-content/main-content.stories.js
+++ b/src/main-content/main-content.stories.js
@@ -1,0 +1,8 @@
+import { storiesOf } from "@storybook/html";
+import html from "./main-content.stories.html";
+import "./main-content.css";
+import { htmlStory } from "../story-helpers";
+
+storiesOf("OpenMRS Styleguide", module).add("Main Content", () =>
+  htmlStory(html)
+);

--- a/src/spacing/spacing.css
+++ b/src/spacing/spacing.css
@@ -1,8 +1,7 @@
 /* See https://docs.google.com/presentation/d/1YqMMW0Cq5siE_9FG-ipWTzF73KToIw7ewmr1Y8VAjJ8/edit#slide=id.g5bf07c575d_0_0
 */
 
-html,
-body {
+* {
   box-sizing: border-box;
 }
 

--- a/src/styleguide-entry.js
+++ b/src/styleguide-entry.js
@@ -8,3 +8,4 @@ import "./button/button.css";
 import "./logo/logo.js";
 import "./icons/icons.js";
 import "./inputs/input.css";
+import "./main-content/main-content.css";


### PR DESCRIPTION
See https://issues.openmrs.org/projects/MF/issues/MF-30. This establishes the pattern for making main content aware of the top and side navbars.

<img width="1469" alt="image" src="https://user-images.githubusercontent.com/5524384/63656566-bafe8980-c752-11e9-8184-f3beab14085a.png">
