### PR TITLE
MF-47: Use Apple's system font on iphones and ipads.

### DIFF
--- a/src/typography/typography.css
+++ b/src/typography/typography.css
@@ -3,6 +3,13 @@ body {
   font-family: "Roboto", sans-serif;
 }
 
+/* https://issues.openmrs.org/projects/MF/issues/MF-47 */
+@supports (font: -apple-system-body) {
+  html {
+    font: -apple-system-body;
+  }
+}
+
 .omrs-type-serif {
   font-family: "Merriweather", serif;
 }

--- a/src/typography/typography.css
+++ b/src/typography/typography.css
@@ -3,7 +3,10 @@ body {
   font-family: "Roboto", sans-serif;
 }
 
-/* https://issues.openmrs.org/projects/MF/issues/MF-47 */
+/*
+  https://issues.openmrs.org/projects/MF/issues/MF-47
+  https://dev.to/colingourlay/how-to-support-apple-s-dynamic-text-in-your-web-content-with-css-40c0
+*/
 @supports (font: -apple-system-body) {
   html {
     font: -apple-system-body;


### PR DESCRIPTION
See https://issues.openmrs.org/projects/MF/issues/MF-47

Apple phones and tablets do not support `rem` unless you change the entire font to be the apple system default.