### PR TITLE
Implementing .omrs-medium 

### DIFF
--- a/src/typography/typography.css
+++ b/src/typography/typography.css
@@ -18,7 +18,11 @@ body {
 }
 
 .omrs-bold {
-  font-weight: bold;
+  font-weight: 700;
+}
+
+.omrs-medium {
+  font-weight: 500;
 }
 
 .omrs-italic {

--- a/src/typography/typography.stories.html
+++ b/src/typography/typography.stories.html
@@ -89,6 +89,27 @@
         </div>
       </div>
     </div>
+
+    <div class="omrs-medium"><%- mediumText %></div>
+    <div class="examples">
+      <div class="tabs">
+        <div lang="html" class="tab">HTML</div>
+        <div lang="jsx" class="tab">JSX</div>
+      </div>
+      <div class="panels">
+        <div class="panel html">
+          <div class="stories-example lang-html">
+            <div class="omrs-medium"><%- mediumText %></div>
+          </div>
+        </div>
+        <div class="panel jsx">
+          <div class="stories-example lang-html">
+            <div className="omrs-medium"><%- mediumText %></div>
+          </div>
+        </div>
+      </div>
+    </div>
+
     <div class="omrs-italic"><%- italicText %></div>
     <div class="examples">
       <div class="tabs">

--- a/src/typography/typography.stories.js
+++ b/src/typography/typography.stories.js
@@ -7,6 +7,7 @@ import "./typography.css";
 
 storiesOf("OpenMRS Styleguide", module).add("Typography & Font", () => {
   const boldText = text("Bold text", "Bolded text");
+  const mediumText = text("Medium text", "Medium text");
   const italicText = text("Italic text", "Italic text");
   const underlinedText = text("Underlined text", "Underlined text");
   const title1Text = text("Title 1 text", "Title 1 text");
@@ -21,6 +22,7 @@ storiesOf("OpenMRS Styleguide", module).add("Typography & Font", () => {
   return htmlStory(
     ejs.render(html, {
       boldText,
+      mediumText,
       italicText,
       underlinedText,
       title1Text,


### PR DESCRIPTION
Changed the `omrs-bold` to font-weight:700 and `omrs-medium` to font-weight:500 to match figma designs.

![Screenshot from 2020-01-27 12-50-07](https://user-images.githubusercontent.com/28008754/73164839-c3912c80-4103-11ea-9c9f-d3dad0cbe147.png)
