### PR TITLE
MF-175: Stray blue dot on choose location page

### DIFF
--- a/src/forms/forms.css
+++ b/src/forms/forms.css
@@ -138,7 +138,6 @@
 /* Radio button styles two */
 .omrs-radio-button input[type="radio"] + label {
   display: inline-flex;
-  position: absolute;
   left: 0;
 }
 

--- a/src/forms/forms.css
+++ b/src/forms/forms.css
@@ -164,8 +164,8 @@
   height: 0.625rem;
   width: 0.625rem;
   transform: translate(-50%, -50%);
-  left: 0.625rem;
-  top: 0.625rem;
+  left: 0.875rem;
+  top: 0.875rem;
 }
 
 .omrs-radio-button input[type="radio"]:checked + label::before {


### PR DESCRIPTION
https://issues.openmrs.org/browse/MF-175

The absolute positioning being applied on the input label in the style guide conflicts with positioning being applied on the labels in [esm-login](https://github.com/openmrs/openmrs-esm-login/blob/b4fec76945248d7a77604904826123202883f1c3/src/styles.css#L113).