### PR TITLE
MF-211: Add styling for invalid states for date and time inputs

### DIFF
--- a/src/forms/forms.css
+++ b/src/forms/forms.css
@@ -231,6 +231,17 @@
   fill: var(--omrs-color-interaction);
 }
 
+.omrs-datepicker input[type="date"]:invalid,
+.omrs-datepicker input[type="time"]:invalid {
+  color: var(--omrs-color-danger);
+  border: 1px solid var(--omrs-color-danger);
+}
+
+.omrs-datepicker input[type="date"]:invalid + svg,
+.omrs-datepicker input[type="time"]:invalid + svg {
+  fill: var(--omrs-color-danger);
+}
+
 /* dropdown */
 
 .omrs-dropdown {


### PR DESCRIPTION
https://issues.openmrs.org/browse/MF-211

Presently, we have styling being applied to date and time inputs when their states are deemed valid. We should have styling applied to these inputs when their data are invalid as well.

This commit proposes applying a border around the input with the class `omrs-color-danger`. The input's color would change to `omrs-color-danger` as well as the `fill` property of the svg icon in the date picker field.

![Screenshot 2020-05-13 at 10 16 26](https://user-images.githubusercontent.com/8509731/81784722-f4a43a00-9505-11ea-96f3-dec0df50c23d.png)
