### PR TITLE
MF-243: Fix font properties for date and time inputs

### DIFF
--- a/src/forms/forms.css
+++ b/src/forms/forms.css
@@ -190,6 +190,12 @@
   display: inline-flex;
 }
 
+.omrs-datepicker input[type="date"],
+.omrs-datepicker input[type="time"] {
+  font-family: "Roboto";
+  font-size: 1rem;
+}
+
 .omrs-datepicker input[type="date"]::-webkit-inner-spin-button,
 .omrs-datepicker input[type="time"]::-webkit-inner-spin-button {
   display: none;


### PR DESCRIPTION
The fonts used in `time` and `date` inputs in forms look a bit small and can be difficult to read at a glance. Setting the font face to Roboto (per the [figma designs](https://www.figma.com/file/YyVhWTNp89bNiOGadYrHBk/Patient-Chart---Master-(current-file)?node-id=5178%3A1230)) and bumping the size to 1rem makes them a lot more readable.

<img width="807" alt="Screenshot 2020-06-10 at 22 28 08" src="https://user-images.githubusercontent.com/8509731/84311155-80dc6800-ab6b-11ea-9744-63585c06e6da.png">

<img width="819" alt="Screenshot 2020-06-10 at 22 29 15" src="https://user-images.githubusercontent.com/8509731/84311168-8639b280-ab6b-11ea-8622-5115e35eea52.png">
