### PR TITLE
MF-264: Fixed issue with toast not closing when X button is clicked

### DIFF
--- a/src/toasts/toast.component.js
+++ b/src/toasts/toast.component.js
@@ -43,7 +43,10 @@ export default function Toast({ toast, closeToastRef, isClosing }) {
     >
       <span>{description}</span>
       <span>
-        <button className="omrs-btn-icon-medium" onClick={close}>
+        <button
+          className="omrs-btn-icon-medium"
+          onClick={() => closeToastRef.current(toast)}
+        >
           <svg className="omrs-icon" fill="var(--omrs-color-ink-white)">
             <use xlinkHref="#omrs-icon-close" />
           </svg>


### PR DESCRIPTION
This PR fixes an issue where the close button 
![error](https://user-images.githubusercontent.com/28008754/86332230-e693af80-bc52-11ea-80e2-55d2725667ac.png)

the toast doesn't close. 

[MF-264](https://issues.openmrs.org/projects/MF/issues/MF-264?filter=allissues)
