### PR TITLE
follow up of carbon css

### DIFF
--- a/src/canvas/canvas.css
+++ b/src/canvas/canvas.css
@@ -4,3 +4,7 @@ body {
   margin: 0;
   padding: 0;
 }
+
+.canvas {
+  background-color: var(--omrs-color-bg-low-contrast);
+}

--- a/src/carbon-esm-styleguide.css
+++ b/src/carbon-esm-styleguide.css
@@ -1,0 +1,2 @@
+/* importing carbon css files from node_modules */
+@import "~carbon-components/css/carbon-components.min.css";

--- a/src/carbon-esm-styleguide.js
+++ b/src/carbon-esm-styleguide.js
@@ -1,3 +1,3 @@
-import "../node_modules/carbon-components/css/carbon-components.min.css";
+import "./carbon-esm-styleguide.css";
 
-import "../node_modules/carbon-icons/dist/carbon-icons.js";
+import "carbon-icons/dist/carbon-icons.js";


### PR DESCRIPTION
At the moment when you run `npm run build,` webpack doesn't bundle carbon-styles 